### PR TITLE
Accept **kwargs in DjangoScssFilter

### DIFF
--- a/django_pyscss/compressor.py
+++ b/django_pyscss/compressor.py
@@ -11,10 +11,10 @@ from django_pyscss.scss import DjangoScss
 class DjangoScssFilter(FilterBase):
     compiler = DjangoScss()
 
-    def __init__(self, content, attrs=None, filter_type=None, filename=None):
+    def __init__(self, content, attrs=None, filter_type=None, filename=None, **kwargs):
         # It looks like there is a bug in django-compressor because it expects
         # us to accept attrs.
-        super(DjangoScssFilter, self).__init__(content, filter_type, filename)
+        super(DjangoScssFilter, self).__init__(content, filter_type, filename, **kwargs)
         try:
             # this is a link tag which means there is an SCSS file being
             # referenced.


### PR DESCRIPTION
Compressor added a charset argument that was breaking here.
