### PR TITLE
Python 3 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 tmp/
 .coverage
 htmlcov/
+__pycache__
+*.pyc

--- a/django_pyscss/compressor.py
+++ b/django_pyscss/compressor.py
@@ -9,9 +9,11 @@ from django_pyscss.scss import DjangoScss
 
 
 class DjangoScssFilter(FilterBase):
-    compiler = DjangoScss()
+    compiler = None
 
-    def __init__(self, content, attrs=None, filter_type=None, filename=None):
+    def __init__(self, content, attrs=None, filter_type=None, filename=None, charset='utf-8'):
+        self.compiler = DjangoScss(charset=charset)
+
         # It looks like there is a bug in django-compressor because it expects
         # us to accept attrs.
         super(DjangoScssFilter, self).__init__(content, filter_type, filename)

--- a/django_pyscss/scss.py
+++ b/django_pyscss/scss.py
@@ -30,6 +30,12 @@ class DjangoScss(Scss):
     files.
     """
     supported_extensions = ['.scss', '.sass', '.css']
+    charset = 'utf-8'
+
+    def __init__(self, **kwargs):
+        if 'charset' in kwargs:
+            self.charset = kwargs.pop('charset')
+        super(DjangoScss, self).__init__(**kwargs)
 
     def get_file_from_storage(self, filename):
         try:
@@ -87,7 +93,7 @@ class DjangoScss(Scss):
             if full_filename:
                 if full_filename not in self.source_file_index:
                     with storage.open(full_filename) as f:
-                        source = f.read()
+                        source = f.read().decode(self.charset)
 
                     source_file = SourceFile(
                         full_filename,

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def get_version():
     elif stage == 'alpha':
         process = subprocess.Popen('git rev-parse HEAD'.split(), stdout=subprocess.PIPE)
         stdout, stderr = process.communicate()
-        return number + '-' + stdout.strip()[:8]
+        return number + '-' + stdout.decode('utf-8').strip()[:8]
 
 setup(
     name='django-pyscss',


### PR DESCRIPTION
Relates to issue #1 (Python 3 support)

Made setup.py work with Python 3 (convert binary to text).

In Python 3 the SCSS source code must be decoded from binary to text before processing. The latest compressor passes a charset argument to our filter, which will be used. If not passed, it will default to utf-8.

Note that Python 3 support currently depends on the latest (master) compressor and a pyScss with this fix incorporated (pull request submitted): https://github.com/wojas/pyScss/commit/e4cf419509f3c568c108c3196e2fda50bcc37536

NOTE: Tests related to the sprites fail for me, both on python 2.7 and 3.4. The hash is different from what's expected.