### PR TITLE
Put the original path at the end in get_possible_paths

### DIFF
--- a/django_pyscss/scss.py
+++ b/django_pyscss/scss.py
@@ -67,7 +67,6 @@ class DjangoScss(Scss):
             path = path[1:]
         elif relative_to:  # relative import
             path = os.path.join(relative_to, path)
-        paths.append(path)
 
         dirname, filename = os.path.split(path)
         name, ext = os.path.splitext(filename)
@@ -77,6 +76,7 @@ class DjangoScss(Scss):
             search_exts = self.supported_extensions
         for prefix, suffix in product(('_', ''), search_exts):
             paths.append(os.path.join(dirname, prefix + name + suffix))
+        paths.append(path)
         return paths
 
     def _find_source_file(self, filename, relative_to=None):


### PR DESCRIPTION
Make it try all the combinations of prefixes and suffixes first,
and then try the original path. This way if there is a directory
named the same as our file, but without the extension and/or
prefix, we don't try to open it and avoid raising IOError.

Fixes #10.
