### PR TITLE
Fix #14, respect storage.prefix when looking for files

### DIFF
--- a/django_pyscss/utils.py
+++ b/django_pyscss/utils.py
@@ -1,4 +1,5 @@
 import fnmatch
+import os
 
 from django.contrib.staticfiles import finders
 
@@ -12,5 +13,6 @@ def find_all_files(glob):
     """
     for finder in finders.get_finders():
         for path, storage in finder.list([]):
-            if fnmatch.fnmatchcase(path, glob):
+            if fnmatch.fnmatchcase(os.path.join(storage.prefix or '', path),
+                                   glob):
                 yield path, storage


### PR DESCRIPTION
The function `find_all_files` ignored `storage.prefix` when looking
for files, which made it fail when a prefix was used in
`STATICFILES_DIRS`.
