### PR TITLE
Fix #14, respect storage.prefix when looking for files

### DIFF
--- a/django_pyscss/utils.py
+++ b/django_pyscss/utils.py
@@ -1,4 +1,5 @@
 import fnmatch
+import os
 
 from django.contrib.staticfiles import finders
 
@@ -12,5 +13,6 @@ def find_all_files(glob):
     """
     for finder in finders.get_finders():
         for path, storage in finder.list([]):
-            if fnmatch.fnmatchcase(path, glob):
+            if fnmatch.fnmatchcase(os.path.join(storage.prefix or '', path),
+                                   glob):
                 yield path, storage

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -97,6 +97,8 @@ STATIC_ROOT = os.path.join(BASE_DIR, '..', 'tmp', 'static')
 
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'testproject', 'static'),
+    ('css_prefix',
+     os.path.join(BASE_DIR, 'testproject', 'static', 'css', 'prefixed')),
 )
 
 # It doesn't seem like django-compressor respects override_settings

--- a/tests/test_scss.py
+++ b/tests/test_scss.py
@@ -47,6 +47,10 @@ class ImportTestMixin(CompilerTestMixin):
         actual = self.compiler.compile(scss_string='@import "/css/foo.scss";')
         self.assertEqual(clean_css(actual), clean_css(FOO_CONTENTS))
 
+    def test_import_from_staticfiles_dirs_prefixed(self):
+        actual = self.compiler.compile(scss_string='@import "/css_prefix/baz.scss";')
+        self.assertEqual(clean_css(actual), clean_css(FOO_CONTENTS))
+
     def test_import_from_staticfiles_dirs_relative(self):
         actual = self.compiler.compile(scss_string='@import "css/foo.scss";')
         self.assertEqual(clean_css(actual), clean_css(FOO_CONTENTS))


### PR DESCRIPTION
The function `find_all_files` ignored `storage.prefix` when looking
for files, which made it fail when a prefix was used in
`STATICFILES_DIRS`.
