### PR TITLE
Fix #19, Make the import compatible with pyScss version 1.3

### DIFF
--- a/django_pyscss/scss.py
+++ b/django_pyscss/scss.py
@@ -6,9 +6,10 @@ from itertools import product
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.conf import settings
 
-from scss import (
-    Scss, dequote, log, SourceFile, SassRule, config,
-)
+from scss import Scss, log, config
+from scss.util import dequote
+from scss.source import SourceFile
+from scss.rule import SassRule
 
 from django_pyscss.utils import find_all_files
 


### PR DESCRIPTION
In 1.3 they removed some names from **init**, so we have to
import them from their corresponding modules inside pyscss.
