### PR TITLE
Fix #19, Make the import compatible with pyScss version 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
 env:
   - DJANGO_PACKAGE='Django>=1.5,<1.6'
   - DJANGO_PACKAGE='Django>=1.6,<1.7'
+  - PYSCSS_PACKAGE='PyScss>=1.2,<1.3'
+  - PYSCSS_PACKAGE='PyScss>=1.3'
 matrix:
   include:
     - python: "2.6"
@@ -14,6 +16,7 @@ matrix:
       env: DJANGO_PACKAGE='Django>=1.4,<1.5'
 install:
   - pip install -q $DJANGO_PACKAGE --use-mirrors
+  - pip install -q $PYSCSS_PACKAGE --use-mirrors
   - pip install --use-mirrors .
   - pip install coveralls
 script:

--- a/django_pyscss/scss.py
+++ b/django_pyscss/scss.py
@@ -6,9 +6,15 @@ from itertools import product
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.conf import settings
 
-from scss import (
-    Scss, dequote, log, SourceFile, SassRule, config,
-)
+from scss import Scss, log, config
+from scss.util import dequote
+try:
+    # For pyscss 1.3.x.
+    from scss.source import SourceFile
+except ImportError:
+    # For pyscss 1.2.x.
+    from scss import SourceFile
+from scss.rule import SassRule
 
 from django_pyscss.utils import find_all_files
 


### PR DESCRIPTION
In 1.3 they removed some names from **init**, so we have to
import them from their corresponding modules inside pyscss.
