### PR TITLE
Concurrency problem creating assets directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 from setuptools import setup, find_packages
 import subprocess
 import os
+import sys
 
 __doc__ = "Makes it easier to use PySCSS in Django."
 
@@ -20,6 +21,8 @@ tests_require = [
     'django-discover-runner',
 ]
 
+if sys.version_info < (3, 3):
+    tests_require.append('mock')
 
 version = (1, 0, 0, 'alpha')
 


### PR DESCRIPTION
In OpenStack Horizon we are seeing this error intermittently during automated testing:

File exists: '/opt/stack/new/horizon/static/scss/assets'
http://logs.openstack.org/81/120281/3/check/check-tempest-dsvm-neutron-full/fbe5341/logs/screen-horizon.txt.gz

It looks like the problem is in this line
https://github.com/fusionbox/django-pyscss/blob/master/django_pyscss/scss.py#L161

It would be great if that code didn't throw the File Exists error if the path was created successfully by another thread/process.
