### PR TITLE
Compatibility with pyScss 1.3, almost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ tmp/
 .coverage
 htmlcov/
 /dist/
+/*.egg
+*.pyc
+.*.sw*
+.sw*

--- a/README.rst
+++ b/README.rst
@@ -36,30 +36,28 @@ Rendering SCSS manually
 
 You can render SCSS manually from a string like this::
 
-    from django_pyscss.scss import DjangoScss
+    from django_pyscss.scss import make_django_scss_compiler
 
-    compiler = DjangoScss()
-    compiler.compile(scss_string=".foo { color: green; }")
+    compiler = make_django_scss_compiler()
+    compiler.compile_string(".foo { color: green; }")
 
 You can render SCSS from a file like this::
 
-    from django_pyscss.scss import DjangoScss
+    from django_pyscss.scss import make_django_scss_compiler
 
-    compiler = DjangoScss()
-    compiler.compile(scss_file='css/styles.scss')
+    compiler = make_django_scss_compiler()
+    compiler.compile(css/styles.scss')
 
 The file needs to be able to be located by staticfiles finders in order to be
 used.
 
 
-.. class:: django_pyscss.scss.DjangoScss
+.. function:: django_pyscss.scss.make_django_scss_compiler
 
-    A subclass of :class:`scss.Scss` that uses the Django staticfiles storage
-    and finders instead of the filesystem.  This obsoletes the load_paths
-    option that was present previously by searching instead in your staticfiles
-    directories.
+    Creates a :class:`scss.compiler.Compiler` configured to use Django
+    staticfiles storage and finders instead of the filesystem.
 
-    In DEBUG mode, DjangoScss will search using all of the finders to find the
+    In DEBUG mode, the compiler will search using all of the finders to find the
     file.  If you are not in DEBUG mode, it assumes you have run collectstatic
     and will only use staticfiles_storage to find the file.
 

--- a/django_pyscss/scss.py
+++ b/django_pyscss/scss.py
@@ -1,16 +1,16 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
-from itertools import product
+from pathlib import Path
 
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.conf import settings
 
-from scss import (
-    Scss, dequote, log, SourceFile, SassRule, config,
-)
+from scss import Scss
+import scss.config as config
 
 from django_pyscss.utils import find_all_files
+from django.contrib.staticfiles import finders
 
 
 # TODO: It's really gross to modify this global settings variable.
@@ -24,200 +24,57 @@ config.ASSETS_ROOT = os.path.join(settings.STATIC_ROOT, 'scss', 'assets')
 config.ASSETS_URL = staticfiles_storage.url('scss/assets/')
 
 
+class DjangoOrigin(object):
+    def __init__(self, path=Path()):
+        self.path = path
+
+    def __str__(self):
+        me = "[django.contrib.staticfiles]"
+        if self.path == Path():
+            return me
+        else:
+            return me + "/" + str(self.path)
+
+    def __div__(self, other):
+        return DjangoOrigin(self.path / other)
+
+    __truediv__ = __div__
+
+    @property
+    def realpath(self):
+        # TODO this seems like it should use Storage, but the only way to get a
+        # Storage out of the finders module is to use list(), which iterates
+        # over every single file needlessly.
+        # TODO this doesn't limit itself to only the staticfiles finder in
+        # non-debug mode
+        found = finders.find(str(self.path))
+        if found:
+            return Path(found)
+        else:
+            return None
+
+    def is_absolute(self):
+        return True
+
+    def exists(self):
+        return bool(self.realpath)
+
+    def open(self, *args):
+        if self.realpath:
+            return self.realpath.open(*args)
+        else:
+            raise IOError
+
+
 class DjangoScss(Scss):
     """
     A subclass of the Scss compiler that uses the storages API for accessing
     files.
     """
-    supported_extensions = ['.scss', '.sass', '.css']
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('search_paths', []).append(DjangoOrigin())
+        super(DjangoScss, self).__init__(*args, **kwargs)
 
-    def get_file_from_storage(self, filename):
-        try:
-            filename = staticfiles_storage.path(filename)
-        except NotImplementedError:
-            # remote storages don't implement path
-            pass
-        if staticfiles_storage.exists(filename):
-            return filename, staticfiles_storage
-        else:
-            return None, None
-
-    def get_file_from_finders(self, filename):
-        for file_and_storage in find_all_files(filename):
-            return file_and_storage
-        return None, None
-
-    def get_file_and_storage(self, filename):
-        # TODO: the switch probably shouldn't be on DEBUG
-        if settings.DEBUG:
-            return self.get_file_from_finders(filename)
-        else:
-            return self.get_file_from_storage(filename)
-
-    def get_possible_import_paths(self, path, relative_to=None):
-        """
-        Returns an iterable of possible paths for an import.
-
-        relative_to is None in the case that the SCSS is being rendered from a
-        string or if it is the first file.
-        """
-        paths = []
-
-        if path.startswith('/'):  # absolute import
-            path = path[1:]
-        elif relative_to:  # relative import
-            path = os.path.join(relative_to, path)
-
-        dirname, filename = os.path.split(path)
-        name, ext = os.path.splitext(filename)
-        if ext:
-            search_exts = [ext]
-        else:
-            search_exts = self.supported_extensions
-        for prefix, suffix in product(('_', ''), search_exts):
-            paths.append(os.path.join(dirname, prefix + name + suffix))
-        paths.append(path)
-        return paths
-
-    def _find_source_file(self, filename, relative_to=None):
-        paths = self.get_possible_import_paths(filename, relative_to)
-        log.debug('Searching for %s in %s', filename, paths)
-        for name in paths:
-            full_filename, storage = self.get_file_and_storage(name)
-            if full_filename:
-                if full_filename not in self.source_file_index:
-                    with storage.open(full_filename) as f:
-                        source = f.read()
-
-                    source_file = SourceFile(
-                        full_filename,
-                        source,
-                    )
-                    # SourceFile.__init__ calls os.path.realpath on this, we don't want
-                    # that, we want them to remain relative.
-                    source_file.parent_dir = os.path.dirname(name)
-                    self.source_files.append(source_file)
-                    self.source_file_index[full_filename] = source_file
-                return self.source_file_index[full_filename]
-
-    def _do_import(self, rule, scope, block):
-        """
-        Implements @import using the django storages API.
-        """
-        # Protect against going to prohibited places...
-        if any(scary_token in block.argument for scary_token in ('..', '://', 'url(')):
-            rule.properties.append((block.prop, None))
-            return
-
-        full_filename = None
-        names = block.argument.split(',')
-        for name in names:
-            name = dequote(name.strip())
-
-            relative_to = rule.source_file.parent_dir
-            source_file = self._find_source_file(name, relative_to)
-
-            if source_file is None:
-                i_codestr = self._do_magic_import(rule, scope, block)
-
-                if i_codestr is not None:
-                    source_file = SourceFile.from_string(i_codestr)
-                    self.source_files.append(source_file)
-                    self.source_file_index[full_filename] = source_file
-
-            if source_file is None:
-                log.warn("File to import not found or unreadable: '%s' (%s)", name, rule.file_and_line)
-                continue
-
-            import_key = (name, source_file.parent_dir)
-            if rule.namespace.has_import(import_key):
-                # If already imported in this scope, skip
-                continue
-
-            _rule = SassRule(
-                source_file=source_file,
-                lineno=block.lineno,
-                import_key=import_key,
-                unparsed_contents=source_file.contents,
-
-                # rule
-                options=rule.options,
-                properties=rule.properties,
-                extends_selectors=rule.extends_selectors,
-                ancestry=rule.ancestry,
-                namespace=rule.namespace,
-            )
-            rule.namespace.add_import(import_key, rule.import_key, rule.file_and_line)
-            self.manage_children(_rule, scope)
-
-    def Compilation(self, scss_string=None, scss_file=None, super_selector=None,
-                    filename=None, is_sass=None, line_numbers=True,
-                    relative_to=None):
-        """
-        Overwritten to call _find_source_file instead of
-        SourceFile.from_filename.  Also added the relative_to option.
-        """
-        if not os.path.exists(config.ASSETS_ROOT):
-            os.makedirs(config.ASSETS_ROOT)
-        if super_selector:
-            self.super_selector = super_selector + ' '
-        self.reset()
-
-        source_file = None
-        if scss_string is not None:
-            source_file = SourceFile.from_string(scss_string, filename, is_sass, line_numbers)
-            # Set the parent_dir to be something meaningful instead of the
-            # current working directory, which is never correct for DjangoScss.
-            source_file.parent_dir = relative_to
-        elif scss_file is not None:
-            # Call _find_source_file instead of SourceFile.from_filename
-            source_file = self._find_source_file(scss_file)
-
-        if source_file is not None:
-            # Clear the existing list of files
-            self.source_files = []
-            self.source_file_index = dict()
-
-            self.source_files.append(source_file)
-            self.source_file_index[source_file.filename] = source_file
-
-        # this will compile and manage rule: child objects inside of a node
-        self.parse_children()
-
-        # this will manage @extends
-        self.apply_extends()
-
-        rules_by_file, css_files = self.parse_properties()
-
-        all_rules = 0
-        all_selectors = 0
-        exceeded = ''
-        final_cont = ''
-        files = len(css_files)
-        for source_file in css_files:
-            rules = rules_by_file[source_file]
-            fcont, total_rules, total_selectors = self.create_css(rules)
-            all_rules += total_rules
-            all_selectors += total_selectors
-            if not exceeded and all_selectors > 4095:
-                exceeded = " (IE exceeded!)"
-                log.error("Maximum number of supported selectors in Internet Explorer (4095) exceeded!")
-            if files > 1 and self.scss_opts.get('debug_info', False):
-                if source_file.is_string:
-                    final_cont += "/* %s %s generated add up to a total of %s %s accumulated%s */\n" % (
-                        total_selectors,
-                        'selector' if total_selectors == 1 else 'selectors',
-                        all_selectors,
-                        'selector' if all_selectors == 1 else 'selectors',
-                        exceeded)
-                else:
-                    final_cont += "/* %s %s generated from '%s' add up to a total of %s %s accumulated%s */\n" % (
-                        total_selectors,
-                        'selector' if total_selectors == 1 else 'selectors',
-                        source_file.filename,
-                        all_selectors,
-                        'selector' if all_selectors == 1 else 'selectors',
-                        exceeded)
-            final_cont += fcont
-
-        return final_cont
+    def compile(self, *args, **kwargs):
+        kwargs.setdefault('import_static_css', True)
+        return super(DjangoScss, self).compile(*args, **kwargs)

--- a/django_pyscss/scss.py
+++ b/django_pyscss/scss.py
@@ -7,6 +7,7 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from django.conf import settings
 
 from scss import Scss
+from scss.compiler import Compiler
 import scss.config as config
 
 from django_pyscss.utils import find_all_files
@@ -66,10 +67,25 @@ class DjangoOrigin(object):
             raise IOError
 
 
+def make_django_scss_compiler(**kwargs):
+    """Create a :class:`scss.Compiler` that uses the storage API for finding
+    files.
+    """
+    # Add the Django loader to the search path
+    kwargs.setdefault('search_path', []).append(DjangoOrigin())
+
+    # Make @import work on .css files, rather than leaving them be
+    kwargs.setdefault('import_static_css', True)
+
+    return Compiler(**kwargs)
+
+
 class DjangoScss(Scss):
     """
     A subclass of the Scss compiler that uses the storages API for accessing
     files.
+
+    DEPRECATED; use :func:`make_django_scss_compiler` instead.
     """
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('search_paths', []).append(DjangoOrigin())

--- a/django_pyscss/scss.py
+++ b/django_pyscss/scss.py
@@ -9,6 +9,11 @@ from django.conf import settings
 from scss import Scss
 from scss.compiler import Compiler
 import scss.config as config
+from scss.extension.bootstrap import BootstrapExtension
+from scss.extension.core import CoreExtension
+from scss.extension.compass import CompassExtension
+from scss.extension.extra import ExtraExtension
+from scss.extension.fonts import FontsExtension
 
 from django_pyscss.utils import find_all_files
 from django.contrib.staticfiles import finders
@@ -71,6 +76,15 @@ def make_django_scss_compiler(**kwargs):
     """Create a :class:`scss.Compiler` that uses the storage API for finding
     files.
     """
+    # Load all the built-in extensions by default
+    kwargs.setdefault('extensions', [
+        CoreExtension,
+        ExtraExtension,
+        FontsExtension,
+        CompassExtension,
+        BootstrapExtension,
+    ])
+
     # Add the Django loader to the search path
     kwargs.setdefault('search_path', []).append(DjangoOrigin())
 

--- a/tests/test_scss.py
+++ b/tests/test_scss.py
@@ -6,7 +6,7 @@ from django.test.utils import override_settings
 from django.conf import settings
 from scss.errors import SassImportError
 
-from django_pyscss.scss import DjangoScss
+from django_pyscss.scss import make_django_scss_compiler
 
 from tests.utils import clean_css, CollectStaticTestCase
 
@@ -37,67 +37,64 @@ with open(os.path.join(settings.BASE_DIR, 'testproject', 'static', 'css', 'path_
 
 class CompilerTestMixin(object):
     def setUp(self):
-        self.compiler = DjangoScss(scss_opts={
-            # No compress so that I can compare more easily
-            'compress': 0,
-        })
+        self.compiler = make_django_scss_compiler()
         super(CompilerTestMixin, self).setUp()
 
 
 class ImportTestMixin(CompilerTestMixin):
     def test_import_from_staticfiles_dirs(self):
-        actual = self.compiler.compile(scss_string='@import "/css/foo.scss";')
+        actual = self.compiler.compile_string('@import "/css/foo.scss";')
         self.assertEqual(clean_css(actual), clean_css(FOO_CONTENTS))
 
     def test_import_from_staticfiles_dirs_prefixed(self):
-        actual = self.compiler.compile(scss_string='@import "/css_prefix/baz.scss";')
+        actual = self.compiler.compile_string('@import "/css_prefix/baz.scss";')
         self.assertEqual(clean_css(actual), clean_css(FOO_CONTENTS))
 
     def test_import_from_staticfiles_dirs_relative(self):
-        actual = self.compiler.compile(scss_string='@import "css/foo.scss";')
+        actual = self.compiler.compile_string('@import "css/foo.scss";')
         self.assertEqual(clean_css(actual), clean_css(FOO_CONTENTS))
 
     def test_import_from_app(self):
-        actual = self.compiler.compile(scss_string='@import "/css/app1.scss";')
+        actual = self.compiler.compile_string('@import "/css/app1.scss";')
         self.assertEqual(clean_css(actual), clean_css(APP1_CONTENTS))
 
     def test_import_from_app_relative(self):
-        actual = self.compiler.compile(scss_string='@import "css/app1.scss";')
+        actual = self.compiler.compile_string('@import "css/app1.scss";')
         self.assertEqual(clean_css(actual), clean_css(APP1_CONTENTS))
 
     def test_imports_within_file(self):
-        actual = self.compiler.compile(scss_string='@import "/css/app2.scss";')
+        actual = self.compiler.compile_string('@import "/css/app2.scss";')
         self.assertEqual(clean_css(actual), clean_css(APP2_CONTENTS))
 
     def test_relative_import(self):
-        actual = self.compiler.compile(scss_file='/css/bar.scss')
+        actual = self.compiler.compile('/css/bar.scss')
         self.assertEqual(clean_css(actual), clean_css(FOO_CONTENTS))
 
     def test_bad_import(self):
         self.assertRaises(
             SassImportError,
-            self.compiler.compile,
-            scss_string='@import "this-file-does-not-and-should-never-exist.scss";',
+            self.compiler.compile_string,
+            '@import "this-file-does-not-and-should-never-exist.scss";',
         )
 
     def test_no_extension_import(self):
-        actual = self.compiler.compile(scss_string='@import "/css/foo";')
+        actual = self.compiler.compile_string('@import "/css/foo";')
         self.assertEqual(clean_css(actual), clean_css(FOO_CONTENTS))
 
     def test_no_extension_import_sass(self):
-        actual = self.compiler.compile(scss_string='@import "/css/sass_file";')
+        actual = self.compiler.compile_string('@import "/css/sass_file";')
         self.assertEqual(clean_css(actual), clean_css(SASS_CONTENTS))
 
     def test_no_extension_import_css(self):
-        actual = self.compiler.compile(scss_string='@import "/css/css_file";')
+        actual = self.compiler.compile_string('@import "/css/css_file";')
         self.assertEqual(clean_css(actual), clean_css(CSS_CONTENTS))
 
     def test_import_underscore_file(self):
-        actual = self.compiler.compile(scss_string='@import "/css/baz";')
+        actual = self.compiler.compile_string('@import "/css/baz";')
         self.assertEqual(clean_css(actual), clean_css(BAZ_CONTENTS))
 
     def test_import_conflict(self):
-        actual = self.compiler.compile(scss_string='@import "/css/path_conflict";')
+        actual = self.compiler.compile_string('@import "/css/path_conflict";')
         self.assertEqual(clean_css(actual), clean_css(PATH_CONFLICT_CONTENTS))
 
 
@@ -138,11 +135,11 @@ $widgets: sprite-map('images/icons/widget-*.png');
 
 class AssetsTest(CompilerTestMixin, TestCase):
     def test_inline_image(self):
-        actual = self.compiler.compile(scss_string=INLINE_IMAGE)
+        actual = self.compiler.compile_string(INLINE_IMAGE)
         self.assertEqual(clean_css(actual), clean_css(INLINED_IMAGE_EXPECTED))
 
     def test_sprite_images(self):
-        actual = self.compiler.compile(scss_string=SPRITE_MAP)
+        actual = self.compiler.compile_string(SPRITE_MAP)
         # pyScss puts a cachebuster query string on the end of the URLs, lets
         # just check that it made the file that we expected.
         self.assert_(re.search(

--- a/tests/test_scss.py
+++ b/tests/test_scss.py
@@ -1,8 +1,10 @@
 import os
+import re
 
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.conf import settings
+from scss.errors import SassImportError
 
 from django_pyscss.scss import DjangoScss
 
@@ -72,8 +74,11 @@ class ImportTestMixin(CompilerTestMixin):
         self.assertEqual(clean_css(actual), clean_css(FOO_CONTENTS))
 
     def test_bad_import(self):
-        actual = self.compiler.compile(scss_string='@import "this-file-does-not-and-should-never-exist.scss";')
-        self.assertEqual(clean_css(actual), '')
+        self.assertRaises(
+            SassImportError,
+            self.compiler.compile,
+            scss_string='@import "this-file-does-not-and-should-never-exist.scss";',
+        )
 
     def test_no_extension_import(self):
         actual = self.compiler.compile(scss_string='@import "/css/foo";')
@@ -140,4 +145,5 @@ class AssetsTest(CompilerTestMixin, TestCase):
         actual = self.compiler.compile(scss_string=SPRITE_MAP)
         # pyScss puts a cachebuster query string on the end of the URLs, lets
         # just check that it made the file that we expected.
-        self.assertIn('KUZdBAnPCdlG5qfocw9GYw.png', actual)
+        self.assert_(re.search(
+            'url[(]/static/scss/assets/images_icons-.+[.]png[?]_=\d+', actual))


### PR DESCRIPTION
This is what I came up with.  It turns out your `STATIC_URL` hack does still work.

Still not done:

* Trying to compile `/css/bar.scss` doesn't work, just because `Compiler.compile` doesn't consult the search path; it assumes you're feeding it a regular filesystem path.  This isn't terribly hard to fix; I'm just not sure what I want to do about it yet.  Maybe a new `Compiler` entry point?  But there are already a lot of those.

* The `DEBUG` toggle for only searching static files in prod mode was lost and hasn't been restored.

* I just remembered I didn't update `setup.py`, whoops!

Doing this has revealed some places that pyscss's extensibility is still pretty awkward.  I'm not in any hurry to go change everything again, but suffice to say I might have to send you another PR come pyscss 2.0.  API design is hard!  Still, this is rather a bit better than before.  :)