### PR TITLE
Correct pyScss module name in setup.py, as per pypi.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 install_requires = [
     'Django>=1.4',
-    'PyScss>=1.2.0,<1.3.0',
+    'pyScss>=1.2.0,<1.3.0',
 ]
 tests_require = [
     'Pillow',


### PR DESCRIPTION
I do automated packaging, and I've noticed that the name of PyScss module, doesn't match PyPi's name, exactly. setuptools is tolerant with this respect, but my checks were not =) would you mind using capitalisation as per pypi?